### PR TITLE
Refactor/feedback 02 - 컴포넌트 종속성관련

### DIFF
--- a/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/ChatMemberList/ChatMemberList.tsx
+++ b/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/ChatMemberList/ChatMemberList.tsx
@@ -13,6 +13,9 @@ import Link from 'next/link';
 import useWorkspaceId from '@/hooks/useWorkspaceId';
 import { useWorkspaceUserId } from '@/hooks/useWorkspaceUserId';
 
+/**
+ * 컴포넌트의 종속성 관련 개선 필요 예시 01
+ */
 const ChatMemberList = () => {
   const { id } = useParams();
   const workspaceId = useWorkspaceId();

--- a/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/ChatNotice/ChatNotice.tsx
+++ b/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/ChatNotice/ChatNotice.tsx
@@ -11,6 +11,9 @@ import { useGetLatestNotice } from '../../../../_hook/useChatQuery';
 import { handleSubscribeToNotice } from '../../_utils/subscribe';
 import useGetParamsChannelId from '../../../../_hook/useGetParamsChannelId';
 
+/**
+ * 컴포넌트의 종속성 관련 개선 필요 예시 02
+ */
 const ChatNotice = () => {
   const channelId = useGetParamsChannelId();
   const workspaceId = useWorkspaceId();
@@ -18,6 +21,9 @@ const ChatNotice = () => {
   const { data: latestNotice } = useGetLatestNotice({ id: channelId });
   const { handleNoticeUpdates: handleUpdates } = useChatHandlers();
 
+  /**
+   * handleSubscribeToNotice와 useGetParamsChannelId를 묶어서 page단계에서의 hook으로 제공해주는 것이 더 좋을 것 같아요.
+   */
   useEffect(() => {
     if (!channelId) return;
 

--- a/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/Messages/Messages.tsx
+++ b/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/Messages/Messages.tsx
@@ -7,6 +7,9 @@ import { useGetChatMessages, useGetUsersInChannel } from '../../../../_hook/useC
 import useGetParamsChannelId from '../../../../_hook/useGetParamsChannelId';
 import useChatSubscription from '../../_hooks/useChatSubscription';
 
+/**
+ * 컴포넌트의 종속성 관련 개선 필요 예시 03
+ */
 const Messages = () => {
   const channelId = useGetParamsChannelId();
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/UpdateChannelReadAt/UpdateChannelReadAt.tsx
+++ b/src/app/(providers)/(root)/[workspaceId]/channels/(chat)/[id]/(home)/_components/UpdateChannelReadAt/UpdateChannelReadAt.tsx
@@ -4,6 +4,9 @@ import { useEffect } from 'react';
 import useGetParamsChannelId from '../../../../_hook/useGetParamsChannelId';
 import { useMutationUpdateChannelActiveAt } from '../../../../_hook/useChatMutation';
 
+/**
+ * 이것은 컴포넌트라기보다 hook이라고 하는게 더 좋지 않을까요?
+ */
 const UpdateChannelReadAt = () => {
   const channelId = useGetParamsChannelId();
 

--- a/src/components/Layout/PageLayout/PageLayout.tsx
+++ b/src/components/Layout/PageLayout/PageLayout.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+/**
+ * 가능하면 최상단 components/* 에서 사용하는 컴포넌트는 내부의 hooks의 디펜던시가 없도록 유지해주시는 것이 좋습니다.
+ * 만약, hook의 종속성이 발생한다면, 해당 컴포넌트를 랩핑한 요소를 새롭게 만들어서 사용해주세요.
+ */
 import useWorkspaceId from '@/hooks/useWorkspaceId';
 import { StrictPropsWithChildren } from '@/types/common';
 import clsx from 'clsx';
@@ -51,6 +55,23 @@ export const PCWrapper = ({ isHome = false, children }: StrictPropsWithChildren<
   return <div className={`${isHome ? '' : 'lg:pl-[85px] lg:flex'}`}>{children}</div>;
 };
 
+/**
+ * useWorkspaceId를 제거하시고 사용하는 page성격의 컴포넌트에서 props로 가져오도록 변경해주시는 것이 공통 컴포넌트의 순수함을 유지하는데 도움이 됩니다.
+ * (이것이 만약 antd나 material-ui 같은 라이브러리와 같이 외부에서 만들어진 컴포넌트라고 생각해보시면 더 쉽습니다.)
+ *
+ * ```tsx
+ *  const workspaceId = useWorkspaceId();
+ *  return (
+ *    <SelectHeader
+ *      workspaceId={workspaceId}
+ *      isFull={isFull}
+ *      isTodoList={isTodoList}
+ *      isChannels={isChannels}
+ *      className={clsx('hidden !fixed top-0 left-0 z-30 lg:block', className)}
+ *    />
+ *  );
+ * ```
+ */
 export const PCHeader = ({
   isFull = false,
   isTodoList = false,

--- a/src/components/Layout/TopBar/TopBar.tsx
+++ b/src/components/Layout/TopBar/TopBar.tsx
@@ -61,6 +61,17 @@ export const BackButton = ({ className }: { className?: string }) => {
   );
 };
 
+/**
+ * 만약 저라면 이런부분은 이렇게도 해봤을 것 같습니다.
+ * ```tsx
+ * interface TopBarContentProps  {
+ *   children: ReactNode;
+ *   hideBackButton?: boolean;
+ *   left?: ReactNode | ReactNode[];
+ *   right?: ReactNode | ReactNode[];
+ * }
+ * ```
+ */
 const TopBarContent = ({ children, Icon1, Icon2, Icon3, Icon4 }: TopBarContentProps) => {
   return (
     <>


### PR DESCRIPTION
### 컴포넌트의 종속성 관련해서 개선이 필요합니다.**
**아래 내용은 전체적인 코드의 방향성에 따라서 많이 달라질수 있는 부분 같아서 미팅때 좀더 얘기해보면 좋을 것 같습니다 :)**

컴포넌트를 서비스 목적에 따라서 잘 나누어주신것은 좋습니다. 하지만 실제로는 hook의 종속성에 걸려서 다소 컴포넌트만으로 코드를 해석할때는 그 흐름이 뚜렷하게 보이지는 않는 것 같습니다.

이렇게 된 이유중에 하나는 모든 ui 컴포넌트를 _component에 넣어버리면서 생긴 문제라고 생각하는데요. 
외부 종속성이 있는 컴포넌트와 없는 컴포넌트를 디렉터리 구조로 나누는것도 한 방법인 것 같습니다.
ex _component/* _container/*

그리고 page레벨에서 수행해야하는 로직이 일부 컴포넌트에서 구현이 되어 있는데, channel 같은 경우에는 channelId 에 종속되는 케이스가 많다보니 이것을 하나의 hook으로 처리하면 어떨까 생각이드네요.

